### PR TITLE
fix: filter out FlightZonePolygon instances in UpdatePath

### DIFF
--- a/src/Asv.Drones.Gui.Plugin.FlightDocs/Shell/Pages/Map/Anchors/FlightZoneAnchor/FlightZonePolygon.cs
+++ b/src/Asv.Drones.Gui.Plugin.FlightDocs/Shell/Pages/Map/Anchors/FlightZoneAnchor/FlightZonePolygon.cs
@@ -51,7 +51,7 @@ public class FlightZonePolygon : MapAnchorBase
 
     private void UpdatePath()
     {
-        var items = _flightZoneMap.FlightZoneAnchors.Items.ToArray();
+        var items = _flightZoneMap.FlightZoneAnchors.Items.Where(x => x.GetType() != typeof(FlightZonePolygon)).ToArray();
         _cache.Clear();
         _cache.AddRange(items);
     }


### PR DESCRIPTION
This commit modifies the method `UpdatePath()` in the `FlightZonePolygon.cs` file. Earlier, the method was including all items from `_flightZoneMap.FlightZoneAnchors` list in the `_cache` list. Now, the method filters out any items of type `FlightZonePolygon`, ensuring only other types of anchors are included. This prevents self-referencing in the list and avoids populating the list with redundant data.

Asana: https://app.asana.com/0/1203851531040615/1205283152374509/f